### PR TITLE
PR: Changed some conditional preprocessor directives

### DIFF
--- a/include/visionaray/gl/compositing.h
+++ b/include/visionaray/gl/compositing.h
@@ -8,9 +8,9 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 

--- a/include/visionaray/gl/handle.h
+++ b/include/visionaray/gl/handle.h
@@ -8,9 +8,9 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 

--- a/include/visionaray/gl/program.h
+++ b/include/visionaray/gl/program.h
@@ -8,9 +8,9 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 

--- a/include/visionaray/gl/shader.h
+++ b/include/visionaray/gl/shader.h
@@ -8,9 +8,9 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 

--- a/include/visionaray/gl/util.h
+++ b/include/visionaray/gl/util.h
@@ -8,9 +8,9 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 

--- a/src/common/input/glut.h
+++ b/src/common/input/glut.h
@@ -8,7 +8,7 @@
 
 #include <common/config.h>
 
-#if VSNRAY_COMMON_HAVE_GLUT
+#ifdef VSNRAY_COMMON_HAVE_GLUT
 
 #include <visionaray/detail/platform.h>
 

--- a/src/common/viewer_base.cpp
+++ b/src/common/viewer_base.cpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#if VSNRAY_COMMON_HAVE_GLEW
+#ifdef VSNRAY_COMMON_HAVE_GLEW
 #include <GL/glew.h> // glViewport() (TODO!)
 #endif
 
@@ -60,7 +60,7 @@ struct viewer_base::impl
 };
 
 viewer_base* viewer_base::impl::viewer = nullptr;
-    
+
 
 viewer_base::impl::impl(int width, int height, char const* window_title)
     : width(width)

--- a/src/visionaray/gl/bvh_outline_renderer.cpp
+++ b/src/visionaray/gl/bvh_outline_renderer.cpp
@@ -3,9 +3,9 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 
@@ -132,7 +132,7 @@ bool bvh_outline_renderer::init_gl(float const* data, size_t size)
         void main(void)
         {
             gl_FragColor = vec4(1.0);
-        }        
+        }
         )");
     impl_->frag.compile();
 

--- a/src/visionaray/gl/debug_callback.cpp
+++ b/src/visionaray/gl/debug_callback.cpp
@@ -19,7 +19,7 @@
 
 #include <visionaray/config.h>
 
-#if VSNRAY_HAVE_GLEW
+#ifdef VSNRAY_HAVE_GLEW
 #include <GL/glew.h>
 #endif
 

--- a/src/visionaray/gl/util.cpp
+++ b/src/visionaray/gl/util.cpp
@@ -15,7 +15,7 @@ std::string gl::last_error()
     GLenum err = glGetError();
     if (err != GL_NO_ERROR)
     {
-#if VSNRAY_HAVE_GLEW
+#ifdef VSNRAY_HAVE_GLEW
         return std::string(reinterpret_cast<char const*>(glewGetErrorString(err)));
 #endif
     }

--- a/src/visionaray/pixel_format.cpp
+++ b/src/visionaray/pixel_format.cpp
@@ -9,9 +9,9 @@
 #include <map>
 #include <utility>
 
-#if VSNRAY_HAVE_GLEW
+#if defined(VSNRAY_HAVE_GLEW)
 #include <GL/glew.h>
-#elif VSNRAY_HAVE_OPENGLES
+#elif defined(VSNRAY_HAVE_OPENGLES)
 #include <GLES2/gl2.h>
 #endif
 


### PR DESCRIPTION
I'm now trying to build visionaray as a static library using MSVC.
But MSVC does not supports syntax like this:

```cpp
#if VSNRAY_HAVE_GLEW
#endif
```

So I changed these cases to:
```cpp
#ifdef VSNRAY_HAVE_GLEW

(OR)

#if defined(VSNRAY_HAVE_GLEW)
```

It seems that you're preparing for supporting build on MSVC, so I'm making a PR.

Thanks for creating amazing lib**aray**.