### PR TITLE
CMakeLists.txt: Propagating include directory.

### DIFF
--- a/src/visionaray/CMakeLists.txt
+++ b/src/visionaray/CMakeLists.txt
@@ -52,8 +52,6 @@ endforeach()
 set(CONFIG_DIR ${__VSNRAY_VISIONARAY_CONFIG_DIR})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CONFIG_DIR}/config.h)
 
-include_directories(${__VSNRAY_CONFIG_DIR})
-
 
 #---------------------------------------------------------------------------------------------------
 # Visionaray library
@@ -363,7 +361,10 @@ visionaray_add_library(visionaray
     ${VSNRAY_SOURCES}
 )
 
-target_include_directories(visionaray PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(visionaray
+  PUBLIC
+  ${PROJECT_SOURCE_DIR}/include
+  ${__VSNRAY_CONFIG_DIR})
 
 # MSVC + CUDA: link with legacy stdio library
 

--- a/src/visionaray/CMakeLists.txt
+++ b/src/visionaray/CMakeLists.txt
@@ -37,8 +37,6 @@ endif()
 #
 #
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
 set(HEADER_DIR ${PROJECT_SOURCE_DIR}/include/visionaray)
 
 
@@ -365,6 +363,7 @@ visionaray_add_library(visionaray
     ${VSNRAY_SOURCES}
 )
 
+target_include_directories(visionaray PUBLIC ${PROJECT_SOURCE_DIR}/include)
 
 # MSVC + CUDA: link with legacy stdio library
 


### PR DESCRIPTION
This just makes it easier when using the library as a subdirectory (via `add_subdirectory()`) so that you don't have to install it into a temporary directory.