### PR TITLE
CMakeLists.txt: Bump minimum required to 2.8.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 project(visionaray CXX)
 
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.11)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     "${PROJECT_SOURCE_DIR}/cmake"


### PR DESCRIPTION
According to [this](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/version_compatibility_matrix/Commands), it's been available since 2.8.11, released about seven years ago.