### PR TITLE
do not fail find_package(visionaray)

### DIFF
--- a/cmake/visionarayConfig.cmake.in
+++ b/cmake/visionarayConfig.cmake.in
@@ -14,11 +14,11 @@ elseif ("@VSNRAY_GRAPHICS_API@" STREQUAL "GLES")
     find_dependency(OpenGLES)
 endif()
 
-if (@VSNRAY_ENABLE_CUDA@)
+if (@CUDA_FOUND@)
     find_dependency(CUDA)
 endif()
 
-if (@VSNRAY_ENABLE_TBB@)
+if (@TBB_FOUND@)
     find_dependency(TBB)
 endif()
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -2,9 +2,13 @@
 # See the LICENSE file for details.
 
 find_package(Boost COMPONENTS chrono filesystem iostreams system thread REQUIRED)
-find_package(CUDA)
+if (VSNRAY_ENABLE_CUDA)
+    find_package(CUDA)
+endif()
 find_package(Git)
-find_package(TBB)
+if (VSNRAY_ENABLE_TBB)
+    find_package(TBB)
+endif()
 find_package(Threads)
 
 if (NOT GIT_FOUND)


### PR DESCRIPTION
find_package(visionaray) of installed visionaray would fail, if e.g. TBB is not available even though it was not linked against TBB