### PR TITLE
do not overwrite generated visionarayConfig

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -380,13 +380,8 @@ install(DIRECTORY ${COMMON_HEADER_DIR} ${CONFIG_DIR}
 )
 
 install(TARGETS visionaray_common
-    EXPORT visionarayConfig
+    EXPORT visionaray_Exports
     RUNTIME DESTINATION bin COMPONENT libraries
     LIBRARY DESTINATION lib COMPONENT libraries
     ARCHIVE DESTINATION lib COMPONENT libraries
-)
-
-install(EXPORT visionarayConfig
-    NAMESPACE visionaray::
-    DESTINATION lib/cmake/visionaray
 )


### PR DESCRIPTION
visionarayConfig.cmake is generated in src/visionaray directory. Do not overwrite it here, but append to visionaray_Exports instead.