### PR TITLE
Revert "Compile fix for Jetson Nano (NEON vecotor extensions)."

### DIFF
--- a/include/visionaray/detail/aligned_allocator.h
+++ b/include/visionaray/detail/aligned_allocator.h
@@ -14,7 +14,7 @@
 #include "macros.h"
 
 #if VSNRAY_CXX_GCC || VSNRAY_CXX_CLANG
-#if VSNRAY_BASE_ARCH == VSNRAY_BASE_ARCH_ARM
+#if VSNRAY_ARCH == VSNRAY_ARCH_ARM
 
 // TODO:!!!
 

--- a/include/visionaray/detail/point_light.inl
+++ b/include/visionaray/detail/point_light.inl
@@ -38,7 +38,7 @@ inline light_sample<U> point_light<T>::sample(vector<3, U> const& reference_poin
 
     auto pos = position();
 
-    result.dir = vector<3, U>(pos) - reference_point;
+    result.dir = pos - reference_point;
     result.dist = length(result.dir);
     result.intensity = intensity(vector<3, U>(pos)) * constants::pi<U>();
     result.normal = normalize( vector<3, U>(

--- a/include/visionaray/math/simd/detail/neon/int4.inl
+++ b/include/visionaray/math/simd/detail/neon/int4.inl
@@ -42,11 +42,6 @@ VSNRAY_FORCE_INLINE int4::basic_int(int32x4_t const& v)
 {
 }
 
-VSNRAY_FORCE_INLINE int4::basic_int(uint32x4_t const& v)
-    : value(vreinterpretq_s32_u32(v))
-{
-}
-
 VSNRAY_FORCE_INLINE int4::operator int32x4_t() const
 {
     return value;

--- a/include/visionaray/math/simd/detail/neon/mask4.inl
+++ b/include/visionaray/math/simd/detail/neon/mask4.inl
@@ -17,11 +17,6 @@ VSNRAY_FORCE_INLINE mask4::basic_mask(uint32x4_t const& m)
 {
 }
 
-VSNRAY_FORCE_INLINE mask4::basic_mask(int32x4_t const& m)
-    : i(vreinterpretq_u32_s32(m))
-{
-}
-
 VSNRAY_FORCE_INLINE mask4::basic_mask(bool x, bool y, bool z, bool w)
 {
     VSNRAY_ALIGN(16) unsigned data[4] = {

--- a/include/visionaray/math/simd/intrinsics.h
+++ b/include/visionaray/math/simd/intrinsics.h
@@ -69,7 +69,7 @@
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_SSE3
 #elif defined(__SSE2__) || VSNRAY_ARCH == VSNRAY_ARCH_X86_64 // SSE2 is always available on 64-bit Intel compatible platforms
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_SSE2
-#elif defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP)) // Compiler on Jetson Nano doesn't define __ARM_NEON_FP although supported.
+#elif defined(__ARM_NEON) && defined(__ARM_NEON_FP)
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_NEON_FP
 #elif defined(__ARM_NEON)
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_NEON

--- a/include/visionaray/math/simd/neon.h
+++ b/include/visionaray/math/simd/neon.h
@@ -61,7 +61,6 @@ public:
     basic_int(unsigned s);
     basic_int(basic_float<float32x4_t> const& f);
     basic_int(int32x4_t const& v);
-    basic_int(uint32x4_t const& v);
 
     operator int32x4_t() const;
 };
@@ -80,7 +79,6 @@ public:
 
     basic_mask() = default;
     basic_mask(uint32x4_t const& m);
-    basic_mask(int32x4_t const& m);
     basic_mask(bool x, bool y, bool z, bool w);
     basic_mask(bool const v[4]);
     basic_mask(bool b);


### PR DESCRIPTION
Reverts szellmann/visionaray#46

This doesn't work on ARM Mac:

```* thread #5, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000012b86ad68 libanari_library_visionaray.dylib`int visionaray::binned_sah_builder::insert_indices<std::__1::vector<unsigned int, visionaray::aligned_allocator<unsigned int, 16ul>>>(std::__1::vector<unsigned int, visionaray::aligned_allocator<unsigned int, 16ul>>&, visionaray::binned_sah_builder::leaf_info const&) [inlined] visionaray::aligned_allocator<unsigned int, 16ul>::construct(this=0x0000000170142220, p=0x0000000000000000, val=<unavailable>) at aligned_allocator.h:106:9 [opt]
   103 	
   104 	    void construct(pointer p, const_reference val)
   105 	    {
-> 106 	        new(static_cast<void*>(p)) T(val);
   107 	    }
   108 	
   109 	    void destroy(pointer p)```

Simply reopening for now. MacOS is more important than Jetson Nano.