### PR TITLE
[ROCm] Add HIP/ROCm support for AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ option(VSNRAY_ENABLE_3DCONNEXIONCLIENT "Use 3DconnexionClient, if available" OFF
 option(VSNRAY_ENABLE_COCOA "Use Cocoa, if available" OFF)
 option(VSNRAY_ENABLE_COMMON "Build the common library with several utils" ON)
 option(VSNRAY_ENABLE_CUDA "Use CUDA, if available" ON)
+option(VSNRAY_ENABLE_HIP "Use HIP for AMD GPUs" OFF)
 option(VSNRAY_ENABLE_EXAMPLES "Build the programming examples" OFF)
 option(VSNRAY_ENABLE_PBRT_PARSER "Build with pbrtParser" OFF)
 option(VSNRAY_ENABLE_PTEX "Use Ptex, if available" OFF)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Build requirements
 
 - [CMake][1] version 3.1.3 or newer
 - [NVIDIA CUDA Toolkit][4] (optional)
+- [AMD ROCm](https://rocm.docs.amd.com) with hipCUB and rocThrust (optional, for AMD GPU support via HIP)
 
 - Libraries need to ship with C/C++ header files (developer packages)
 
@@ -68,6 +69,18 @@ make install
 Headers, libraries and binaries will then be located in the standard install path of your operating system (usually `/usr/local`).
 
 See the [Getting Started Guide](https://github.com/szellmann/visionaray/wiki/Getting-started) and the [Troubleshooting section](https://github.com/szellmann/visionaray/wiki/Troubleshooting) in the [Wiki](https://github.com/szellmann/visionaray/wiki) for further information.
+
+#### AMD GPUs (ROCm/HIP)
+
+Visionaray's GPU path also targets AMD GPUs through ROCm/HIP. Enable it with `-DVSNRAY_ENABLE_HIP=ON` (mutually exclusive with the CUDA path) and select your GPU architecture, for example `gfx90a` (MI200), `gfx1100` (RDNA3), or `gfx1201` (RDNA4). It requires a ROCm install with hipCUB and rocThrust.
+
+```Shell
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+  -DVSNRAY_ENABLE_HIP=ON -DVSNRAY_ENABLE_CUDA=OFF \
+  -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++
+make
+```
 
 ### Windows
 

--- a/include/visionaray/detail/bvh/lbvh.h
+++ b/include/visionaray/detail/bvh/lbvh.h
@@ -15,6 +15,12 @@
 #include <cub/cub.cuh>
 #endif
 
+#ifdef __HIPCC__
+#include <visionaray/hip/device_vector.h>
+#include <visionaray/hip/safe_call.h>
+#include <hipcub/hipcub.hpp>
+#endif
+
 #include <visionaray/aligned_vector.h>
 #include <visionaray/morton.h>
 
@@ -38,6 +44,8 @@ inline unsigned clz(unsigned val)
 {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 200
     return __clz(val);
+#elif defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__
+    return __clz(val);
 #elif defined(_WIN32)
     return __lzcnt(val);
 #else
@@ -45,7 +53,7 @@ inline unsigned clz(unsigned val)
 #endif
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 
 struct CustomLess
 {
@@ -90,7 +98,7 @@ inline float atomicMax(float *address, float val)
     return __int_as_float(ret);
 }
 
-#endif
+#endif // __CUDACC__ || __HIPCC__
 
 
 namespace lbvh
@@ -184,7 +192,7 @@ inline vec2i determine_range(prim_ref* refs, int num_prims, int i, int& split)
         return vec2i(j, i);
 }
 
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || defined(__HIPCC__)
 
 //-------------------------------------------------------------------------------------------------
 // Node data structure only used for construction w/ Karras' algorithm. Alignment is bad, but
@@ -209,7 +217,7 @@ struct node
 
 
 //-------------------------------------------------------------------------------------------------
-// CUDA kernels
+// GPU kernels (CUDA and HIP)
 //
 
 template <typename P>
@@ -465,7 +473,7 @@ static __global__ void sequence(
     indices[index] = index;
 }
 
-#endif // __CUDACC__
+#endif // __CUDACC__ || __HIPCC__
 
 } // lbvh
 } // detail
@@ -858,6 +866,196 @@ struct lbvh_builder
     }
 
 #endif // __CUDACC__
+
+
+#ifdef __HIPCC__
+
+    //-------------------------------------------------------------------------
+    // HIP GPU builder based on Karras, Maximizing parallelism in the construction
+    // of BVHs octrees and k-d trees (2012).
+    //
+
+    hip::device_vector<detail::lbvh::prim_ref> d_prim_refs;
+    hip::device_vector<aabb> d_prim_bounds;
+
+    hipStream_t copy_stream{0};
+
+    lbvh_builder()
+    {
+        HIP_SAFE_CALL(hipStreamCreate(&copy_stream));
+    }
+
+    ~lbvh_builder()
+    {
+        HIP_SAFE_CALL(hipStreamDestroy(copy_stream));
+    }
+
+    template <typename P>
+    hip_index_bvh<P> build(hip_index_bvh<P> /* */, P* primitives, size_t num_prims)
+    {
+        using namespace detail::lbvh;
+
+        hip_index_bvh<P> tree(primitives, num_prims);
+
+        if (primitives == nullptr || num_prims == 0)
+        {
+            return tree;
+        }
+
+        P* first = primitives;
+        P* last = primitives + num_prims;
+
+
+        // Scene and centroid bounding boxes
+        aabb invalid;
+        invalid.invalidate();
+        hip::device_vector<aabb> bounds(2, invalid);
+
+        aabb* scene_bounds_ptr = bounds.data();
+        aabb* centroid_bounds_ptr = bounds.data() + 1;
+
+
+        // Compute primitive bounding boxes and centroids
+        d_prim_bounds.resize(last - first);
+        hip::device_vector<vec3> centroids(last - first);
+
+        {
+            size_t num_threads = 1024;
+
+            compute_bounds_and_centroids<<<div_up(num_prims, num_threads), num_threads>>>(
+                    d_prim_bounds.data(),
+                    centroids.data(),
+                    scene_bounds_ptr,
+                    centroid_bounds_ptr,
+                    primitives,
+                    num_prims
+                    );
+        }
+
+        // Compute morton codes for centroids
+        d_prim_refs.resize(last - first);
+
+        {
+            size_t num_threads = 1024;
+
+            assign_morton_codes<<<div_up(num_prims, num_threads), num_threads>>>(
+                    d_prim_refs.data(),
+                    centroids.data(),
+                    centroid_bounds_ptr,
+                    num_prims
+                    );
+        }
+
+        // Sort prim refs by morton codes
+        void* d_temp_storage = nullptr;
+        size_t temp_storage_bytes = 0;
+        hipcub::DeviceMergeSort::StableSortKeys(
+            d_temp_storage,
+            temp_storage_bytes,
+            d_prim_refs.data(),
+            d_prim_refs.size(),
+            detail::CustomLess()
+            );
+        HIP_SAFE_CALL(hipMalloc(&d_temp_storage, temp_storage_bytes));
+        hipcub::DeviceMergeSort::StableSortKeys(
+            d_temp_storage,
+            temp_storage_bytes,
+            d_prim_refs.data(),
+            d_prim_refs.size(),
+            detail::CustomLess()
+            );
+        HIP_SAFE_CALL(hipFree(d_temp_storage));
+
+        // Use Karras' radix tree algorithm to build hierarchy
+        hip::device_vector<node> inner(num_prims - 1);
+        hip::device_vector<node> leaves(num_prims);
+
+        {
+            size_t num_threads = 1024;
+
+            size_t num_inner = inner.size();
+            if (num_inner > 0)
+            {
+                init_nodes<<<div_up(num_inner, num_threads), num_threads>>>(
+                        inner.data(),
+                        num_inner
+                        );
+            }
+
+            size_t num_leaves = leaves.size();
+            assert(num_leaves > 0); // should have at least one leaf node!
+            init_nodes<<<div_up(num_leaves, num_threads), num_threads>>>(
+                    leaves.data(),
+                    num_leaves
+                    );
+        }
+
+        {
+            size_t num_threads = 1024;
+
+            build_hierarchy<<<div_up(num_prims, num_threads), num_threads>>>(
+                    inner.data(),
+                    leaves.data(),
+                    d_prim_refs.data(),
+                    num_prims
+                    );
+        }
+
+        // Expand nodes' bounding boxes by inserting leaves' bounding boxes
+        tree.nodes().resize(inner.size() + leaves.size());
+
+        {
+            size_t num_threads = 1024;
+
+            assign_node_bounds<<<div_up(num_prims, num_threads), num_threads>>>(
+                    inner.data(),
+                    leaves.data(),
+                    d_prim_bounds.data(),
+                    d_prim_refs.data(),
+                    num_prims
+                    );
+        }
+
+        // Convert to Visionaray node format (stores the two children
+        // of a BVH node next to each other in memory)
+        {
+            size_t num_threads = 1024;
+
+            collapse<<<div_up(num_prims, num_threads), num_threads>>>(
+                    tree.nodes().data(),
+                    inner.data(),
+                    leaves.data(),
+                    d_prim_refs.data(),
+                    num_prims
+                    );
+        }
+
+        // Copy primitives to BVH (device to device copy!)
+        tree.primitives().resize(num_prims);
+        HIP_SAFE_CALL(hipMemcpyAsync(
+            tree.primitives().begin(),
+            first,
+            num_prims * sizeof(P),
+            hipMemcpyDefault,
+            copy_stream
+            ));
+        HIP_SAFE_CALL(hipStreamSynchronize(copy_stream));
+
+        // Assign 0,1,2,3,.. indices
+        {
+
+            size_t num_threads = 1024;
+
+            sequence<<<div_up(tree.indices().size(), num_threads), num_threads>>>(
+                    tree.indices().data(),
+                    tree.indices().size()
+                    );
+        }
+
+        return tree;
+    }
+
+#endif // __HIPCC__
 
 
     // TODO:

--- a/include/visionaray/detail/hip_sched.h
+++ b/include/visionaray/detail/hip_sched.h
@@ -1,0 +1,54 @@
+// This file is distributed under the MIT license.
+// See the LICENSE file for details.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+#pragma once
+
+#ifndef VSNRAY_DETAIL_HIP_SCHED_H
+#define VSNRAY_DETAIL_HIP_SCHED_H 1
+
+#include <cstddef>
+
+#include <hip/hip_runtime_api.h>
+
+#include <visionaray/math/forward.h>
+#include <visionaray/math/vector.h>
+
+namespace visionaray
+{
+
+//-------------------------------------------------------------------------------------------------
+// AMD HIP-based scheduler
+//
+//
+// Uses a 2-D HIP grid to schedule ray traversal kernels
+// Default: divide the window into blocks of 16x16 pixels
+// Call hip_sched(vec2ui block_dim) for custom block sizes
+//
+//-------------------------------------------------------------------------------------------------
+
+template <typename R>
+class hip_sched
+{
+public:
+
+    hip_sched() = default;
+    hip_sched(vec2ui block_size);
+    hip_sched(unsigned block_size_x, unsigned block_size_y);
+
+    template <typename K, typename SP>
+    void frame(K kernel, SP sched_params, size_t smem = 0, hipStream_t const& stream = 0);
+
+private:
+
+    vec2ui block_size_ = vec2ui(16, 16);
+    unsigned frame_id_ = 0;
+
+};
+
+} // visionaray
+
+#include "hip_sched.inl"
+
+#endif // VSNRAY_DETAIL_HIP_SCHED_H

--- a/include/visionaray/detail/hip_sched.inl
+++ b/include/visionaray/detail/hip_sched.inl
@@ -1,0 +1,250 @@
+// This file is distributed under the MIT license.
+// See the LICENSE file for details.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+#include <cassert>
+#include <type_traits>
+#include <utility>
+
+#include <hip/hip_runtime_api.h>
+
+#include "../math/detail/math.h" // div_up
+#include "../make_generator.h"
+#include "../make_random_seed.h"
+#include "../packet_traits.h"
+#include "sched_common.h"
+
+namespace visionaray
+{
+namespace detail
+{
+
+//-------------------------------------------------------------------------------------------------
+// HIP kernels
+//
+
+template <
+    typename R,
+    typename PxSamplerT,
+    typename RTRef,
+    typename K,
+    typename ...Args
+    >
+__global__ void hip_render(
+        PxSamplerT      sample_params,
+        unsigned        frame_id,
+        RTRef           rt_ref,
+        K               kernel,
+        Args...         args
+        )
+{
+    using S = typename R::scalar_type;
+    using I = typename simd::int_type<S>::type;
+
+    auto x = blockIdx.x * blockDim.x + threadIdx.x;
+    auto y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= rt_ref.width() || y >= rt_ref.height())
+    {
+        return;
+    }
+
+    expand_pixel<S> ep;
+    auto seed = make_random_seed(
+        convert_to_int(ep.y(y)) * rt_ref.width() + convert_to_int(ep.x(x)),
+        I(frame_id)
+        );
+
+    auto gen = make_generator(S{}, sample_params, seed);
+
+    sample_pixel(
+            kernel,
+            sample_params,
+            R{},
+            gen,
+            rt_ref,
+            x,
+            y,
+            args...
+            );
+}
+
+template <
+    typename R,
+    typename PxSamplerT,
+    typename Intersector,
+    typename RTRef,
+    typename K,
+    typename ...Args
+    >
+__global__ void hip_render(
+        detail::have_intersector_tag    /* */,
+        PxSamplerT                      sample_params,
+        Intersector                     intersector,
+        unsigned                        frame_id,
+        RTRef                           rt_ref,
+        K                               kernel,
+        Args...                         args
+        )
+{
+    using S = typename R::scalar_type;
+    using I = typename simd::int_type<S>::type;
+
+    auto x = blockIdx.x * blockDim.x + threadIdx.x;
+    auto y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= rt_ref.width() || y >= rt_ref.height())
+    {
+        return;
+    }
+
+    expand_pixel<S> ep;
+    auto seed = make_random_seed(
+        convert_to_int(ep.y(y)) * rt_ref.width() + convert_to_int(ep.x(x)),
+        I(frame_id)
+        );
+
+    // TODO: support any sampler
+    random_generator<typename R::scalar_type> gen(seed);
+
+    sample_pixel(
+            detail::have_intersector_tag(),
+            intersector,
+            kernel,
+            sample_params,
+            R{},
+            gen,
+            rt_ref,
+            x,
+            y,
+            args...
+            );
+}
+
+
+//-------------------------------------------------------------------------------------------------
+// Dispatch functions
+//
+
+template <typename R, typename SP, typename ...Args>
+inline void hip_sched_impl_call_render(
+        std::false_type     /* has intersector */,
+        SP&                 sparams,
+        unsigned            frame_id,
+        dim3 const&         grid_size,
+        dim3 const&         block_size,
+        size_t              smem,
+        hipStream_t const&  stream,
+        Args&&...           args
+        )
+{
+    hip_render<R, typename SP::pixel_sampler_type><<<grid_size, block_size, smem, stream>>>(
+            sparams.sample_params,
+            frame_id,
+            std::forward<Args>(args)...
+            );
+}
+
+template <typename R, typename SP, typename ...Args>
+inline void hip_sched_impl_call_render(
+        std::true_type      /* has intersector */,
+        SP const&           sparams,
+        unsigned            frame_id,
+        dim3 const&         grid_size,
+        dim3 const&         block_size,
+        size_t              smem,
+        hipStream_t const&  stream,
+        Args&&...           args
+        )
+{
+    hip_render<R, typename SP::pixel_sampler_type><<<grid_size, block_size, smem, stream>>>(
+            detail::have_intersector_tag(),
+            sparams.sample_params,
+            sparams.intersector,
+            frame_id,
+            std::forward<Args>(args)...
+            );
+}
+
+
+template <typename R, typename K, typename SP>
+inline void hip_sched_impl_frame(
+        K                   kernel,
+        SP                  sparams,
+        unsigned            frame_id,
+        dim3 const&         block_size,
+        size_t              smem,
+        hipStream_t const&  stream
+        )
+{
+    using hip_dim_t = decltype(block_size.x);
+
+    auto w = static_cast<hip_dim_t>(sparams.rt.width());
+    auto h = static_cast<hip_dim_t>(sparams.rt.height());
+
+    dim3 grid_size(
+            div_up(w, block_size.x),
+            div_up(h, block_size.y)
+            );
+
+    hip_sched_impl_call_render<R>(
+            typename detail::sched_params_has_intersector<SP>::type(),
+            sparams,
+            frame_id,
+            grid_size,
+            block_size,
+            smem,
+            stream,
+            sparams.rt.ref(),
+            kernel,
+            sparams.rt.width(),
+            sparams.rt.height(),
+            sparams.cam
+            );
+}
+
+} // detail
+
+
+//-------------------------------------------------------------------------------------------------
+// hip_sched implementation
+//
+
+template <typename R>
+hip_sched<R>::hip_sched(vec2ui block_size)
+    : block_size_(block_size)
+{
+}
+
+template <typename R>
+hip_sched<R>::hip_sched(unsigned block_size_x, unsigned block_size_y)
+    : block_size_(block_size_x, block_size_y)
+{
+}
+
+template <typename R>
+template <typename K, typename SP>
+void hip_sched<R>::frame(K kernel, SP sched_params, size_t smem, hipStream_t const& stream)
+{
+    sched_params.cam.begin_frame();
+
+    sched_params.rt.begin_frame();
+
+    detail::hip_sched_impl_frame<R>(
+            kernel,
+            sched_params,
+            frame_id_,
+            dim3(block_size_.x, block_size_.y),
+            smem,
+            stream
+            );
+
+    sched_params.rt.end_frame();
+
+    sched_params.cam.end_frame();
+
+    ++frame_id_;
+}
+
+} // visionaray

--- a/include/visionaray/detail/macros.h
+++ b/include/visionaray/detail/macros.h
@@ -72,7 +72,7 @@
 // Determine if code is compiled for the CPU or the GPU
 //
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ > 0
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ > 0) || (defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__)
 #define VSNRAY_CPU_MODE 0
 #define VSNRAY_GPU_MODE 1
 #else

--- a/include/visionaray/hip/managed_allocator.h
+++ b/include/visionaray/hip/managed_allocator.h
@@ -1,0 +1,58 @@
+// This file is distributed under the MIT license.
+// See the LICENSE file for details.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+#pragma once
+
+#ifndef VSNRAY_HIP_MANAGED_ALLOCATOR_H
+#define VSNRAY_HIP_MANAGED_ALLOCATOR_H 1
+
+#include <cstddef>
+
+#include <hip/hip_runtime_api.h>
+
+namespace visionaray
+{
+namespace hip
+{
+
+template <typename T>
+class managed_allocator
+{
+public:
+
+    typedef T value_type;
+
+    managed_allocator() = default;
+
+    template <typename U>
+    managed_allocator(managed_allocator<U> const&) {}
+
+    T* allocate(size_t n)
+    {
+        T* ptr = nullptr;
+        hipMallocManaged(&ptr, n * sizeof(T));
+        return ptr;
+    }
+
+    void deallocate(T* ptr, size_t /* n */)
+    {
+        hipFree(ptr);
+    }
+
+    bool operator==(managed_allocator const& /* rhs */) const
+    {
+        return true;
+    }
+
+    bool operator!=(managed_allocator const& rhs) const
+    {
+        return !(*this == rhs);
+    }
+};
+
+} // hip
+} // visionaray
+
+#endif // VSNRAY_HIP_MANAGED_ALLOCATOR_H

--- a/include/visionaray/hip/managed_vector.h
+++ b/include/visionaray/hip/managed_vector.h
@@ -1,0 +1,28 @@
+// This file is distributed under the MIT license.
+// See the LICENSE file for details.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+#pragma once
+
+#ifndef VSNRAY_HIP_MANAGED_VECTOR_H
+#define VSNRAY_HIP_MANAGED_VECTOR_H 1
+
+#include "managed_allocator.h"
+
+namespace visionaray
+{
+namespace hip
+{
+
+//-------------------------------------------------------------------------------------------------
+// An std::vector that stores data in HIP unified memory
+//
+
+template <typename T>
+using managed_vector = std::vector<T, managed_allocator<T>>;
+
+} // hip
+} // visionaray
+
+#endif // VSNRAY_HIP_MANAGED_VECTOR_H

--- a/include/visionaray/random_generator.h
+++ b/include/visionaray/random_generator.h
@@ -8,7 +8,7 @@
 
 #include <type_traits>
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #include <thrust/random.h>
 #else
 #include <random>
@@ -34,7 +34,7 @@ public:
 
 public:
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
     typedef thrust::default_random_engine rand_engine;
     typedef thrust::uniform_real_distribution<T> uniform_dist;
 #else

--- a/include/visionaray/scheduler.h
+++ b/include/visionaray/scheduler.h
@@ -198,6 +198,9 @@ auto make_sched_params(First first, Args&&... args)
 #ifdef __CUDACC__
 #include "detail/cuda_sched.h"
 #endif
+#ifdef __HIPCC__
+#include "detail/hip_sched.h"
+#endif
 #include "detail/simple_sched.h"
 #if !defined(__MINGW32__) && !defined(__MINGW64__)
 #include "detail/tiled_sched.h"

--- a/src/visionaray/CMakeLists.txt
+++ b/src/visionaray/CMakeLists.txt
@@ -13,6 +13,19 @@ if (VSNRAY_ENABLE_CUDA)
   target_link_libraries(visionaray INTERFACE CUDA::cudart)
 endif()
 
+if (VSNRAY_ENABLE_HIP)
+  enable_language(HIP)
+  find_package(hip REQUIRED)
+  find_package(rocthrust REQUIRED)
+  find_package(hipcub REQUIRED)
+  # HIP libraries are available but NOT linked to the INTERFACE target
+  # Targets with HIP sources should link hip::host/device, roc::rocthrust, hip::hipcub
+  # directly to avoid leaking HIP compiler options to CXX-only targets
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+    set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+  endif()
+endif()
+
 target_include_directories(visionaray INTERFACE
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,3 +4,48 @@
 if(VSNRAY_ENABLE_UNITTESTS)
     add_subdirectory(unittests)
 endif()
+
+# HIP test
+if(VSNRAY_ENABLE_HIP)
+  enable_language(HIP)
+  find_package(hip REQUIRED)
+  find_package(rocthrust REQUIRED)
+  find_package(hipcub REQUIRED)
+  find_package(Threads REQUIRED)
+
+  add_executable(hip_test hip_test.hip)
+  set_target_properties(hip_test PROPERTIES
+    HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}"
+    LINKER_LANGUAGE HIP
+  )
+  target_include_directories(hip_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}/../src/visionaray
+  )
+  target_link_libraries(hip_test PRIVATE
+    hip::host
+    hip::device
+    roc::rocthrust
+    hip::hipcub
+    Threads::Threads
+  )
+  add_test(NAME hip_test COMMAND hip_test)
+
+  add_executable(hip_random_test hip_random_test.hip)
+  set_target_properties(hip_random_test PROPERTIES
+    HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}"
+    LINKER_LANGUAGE HIP
+  )
+  target_include_directories(hip_random_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}/../src/visionaray
+  )
+  target_link_libraries(hip_random_test PRIVATE
+    hip::host
+    hip::device
+    roc::rocthrust
+    hip::hipcub
+    Threads::Threads
+  )
+  add_test(NAME hip_random_test COMMAND hip_random_test)
+endif()

--- a/test/hip_random_test.hip
+++ b/test/hip_random_test.hip
@@ -1,0 +1,109 @@
+// This file is distributed under the MIT license.
+// See the LICENSE file for details.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+// HIP test exercising visionaray::random_generator on the device.
+//
+// Constructs random_generator<float> inside a kernel and pulls samples,
+// verifying the thrust-backed device RNG path is actually compiled and
+// produces finite, varied values in [0, 1).
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+
+#include <visionaray/random_generator.h>
+#include <visionaray/hip/device_vector.h>
+#include <visionaray/hip/safe_call.h>
+
+using namespace visionaray;
+
+__global__ void rng_kernel(float* out, int samples_per_thread, int n_threads)
+{
+    int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= n_threads)
+    {
+        return;
+    }
+
+    // Per-thread distinct seed; constructed and consumed entirely on device.
+    random_generator<float> gen(static_cast<unsigned>(tid) * 9781u + 1u);
+
+    for (int s = 0; s < samples_per_thread; ++s)
+    {
+        out[tid * samples_per_thread + s] = gen.next();
+    }
+}
+
+int main()
+{
+    std::cout << "Testing visionaray device random_generator (HIP)..." << std::endl;
+
+    hipDeviceProp_t props;
+    HIP_SAFE_CALL(hipGetDeviceProperties(&props, 0));
+    std::cout << "Device: " << props.name << std::endl;
+    std::cout << "Warp size: " << props.warpSize << std::endl;
+
+    const int n_threads = 4096;
+    const int samples_per_thread = 8;
+    const int total = n_threads * samples_per_thread;
+
+    hip::device_vector<float> d_out(total);
+
+    int block_size = 256;
+    int grid_size = (n_threads + block_size - 1) / block_size;
+    rng_kernel<<<grid_size, block_size>>>(d_out.data(), samples_per_thread, n_threads);
+    HIP_SAFE_CALL(hipGetLastError());
+    HIP_SAFE_CALL(hipDeviceSynchronize());
+
+    std::vector<float> h_out(total);
+    HIP_SAFE_CALL(hipMemcpy(h_out.data(), d_out.data(), total * sizeof(float), hipMemcpyDeviceToHost));
+
+    bool all_finite = true;
+    bool all_in_range = true;
+    double sum = 0.0;
+    float vmin = h_out[0];
+    float vmax = h_out[0];
+    for (int i = 0; i < total; ++i)
+    {
+        float v = h_out[i];
+        if (!std::isfinite(v))
+        {
+            all_finite = false;
+        }
+        if (v < 0.0f || v >= 1.0f)
+        {
+            all_in_range = false;
+        }
+        sum += v;
+        vmin = v < vmin ? v : vmin;
+        vmax = v > vmax ? v : vmax;
+    }
+    double mean = sum / total;
+
+    // "Varied" guard: a broken/degenerate RNG would emit a constant, so the
+    // spread must be wide and the mean near 0.5 for a uniform[0,1) draw.
+    bool varied = (vmax - vmin) > 0.5f;
+    bool mean_ok = mean > 0.3 && mean < 0.7;
+
+    std::cout << "samples=" << total
+              << " min=" << vmin
+              << " max=" << vmax
+              << " mean=" << mean << std::endl;
+
+    if (all_finite && all_in_range && varied && mean_ok)
+    {
+        std::cout << "PASS: device random_generator produced finite, varied values" << std::endl;
+        return 0;
+    }
+
+    std::cerr << "FAIL: finite=" << all_finite
+              << " in_range=" << all_in_range
+              << " varied=" << varied
+              << " mean_ok=" << mean_ok << std::endl;
+    return 1;
+}

--- a/test/hip_test.hip
+++ b/test/hip_test.hip
@@ -1,0 +1,83 @@
+// This file is distributed under the MIT license.
+// See the LICENSE file for details.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+// HIP test to verify visionaray HIP headers compile and run
+
+#include <iostream>
+#include <cstdlib>
+
+#include <hip/hip_runtime.h>
+#include <visionaray/scheduler.h>
+#include <visionaray/math/vector.h>
+#include <visionaray/hip/device_vector.h>
+#include <visionaray/hip/safe_call.h>
+
+using namespace visionaray;
+
+// Simple kernel to verify GPU code runs
+__global__ void add_kernel(float* a, float* b, float* c, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        c[idx] = a[idx] + b[idx];
+    }
+}
+
+int main()
+{
+    std::cout << "Testing visionaray HIP support..." << std::endl;
+
+    // Check device
+    hipDeviceProp_t props;
+    HIP_SAFE_CALL(hipGetDeviceProperties(&props, 0));
+    std::cout << "Device: " << props.name << std::endl;
+    std::cout << "Warp size: " << props.warpSize << std::endl;
+
+    // Test hip::device_vector
+    const int N = 1024;
+    hip::device_vector<float> d_a(N);
+    hip::device_vector<float> d_b(N);
+    hip::device_vector<float> d_c(N);
+
+    // Allocate host data
+    std::vector<float> h_a(N), h_b(N), h_c(N);
+    for (int i = 0; i < N; ++i) {
+        h_a[i] = static_cast<float>(i);
+        h_b[i] = static_cast<float>(i * 2);
+    }
+
+    // Copy to device
+    HIP_SAFE_CALL(hipMemcpy(d_a.data(), h_a.data(), N * sizeof(float), hipMemcpyHostToDevice));
+    HIP_SAFE_CALL(hipMemcpy(d_b.data(), h_b.data(), N * sizeof(float), hipMemcpyHostToDevice));
+
+    // Launch kernel
+    int block_size = 256;
+    int grid_size = (N + block_size - 1) / block_size;
+    add_kernel<<<grid_size, block_size>>>(d_a.data(), d_b.data(), d_c.data(), N);
+
+    HIP_SAFE_CALL(hipDeviceSynchronize());
+
+    // Copy result back
+    HIP_SAFE_CALL(hipMemcpy(h_c.data(), d_c.data(), N * sizeof(float), hipMemcpyDeviceToHost));
+
+    // Verify result
+    bool pass = true;
+    for (int i = 0; i < N; ++i) {
+        float expected = h_a[i] + h_b[i];
+        if (h_c[i] != expected) {
+            std::cerr << "Mismatch at " << i << ": expected " << expected << ", got " << h_c[i] << std::endl;
+            pass = false;
+            break;
+        }
+    }
+
+    if (pass) {
+        std::cout << "PASS: Basic HIP test succeeded" << std::endl;
+        return 0;
+    } else {
+        std::cerr << "FAIL: Basic HIP test failed" << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Completes the experimental HIP support that exists upstream so visionaray's GPU path runs on AMD GPUs through ROCm/HIP, behind an opt-in `VSNRAY_ENABLE_HIP` CMake option (mutually exclusive with the CUDA path, which is unchanged).

Added:
- CMake `VSNRAY_ENABLE_HIP` option (parallel to `VSNRAY_ENABLE_CUDA`).
- HIP scheduler (`detail/hip_sched.h/.inl`) mirroring the CUDA scheduler.
- HIP LBVH builder using hipCUB for GPU BVH construction.
- Missing HIP headers: `hip/managed_allocator.h` and `hip/managed_vector.h`.
- `VSNRAY_GPU_MODE` now detects HIP device compilation.

The port keeps the existing parallel `cuda/` and `hip/` directory structure. HIP sources link `hip::host/device` and rocThrust/hipCUB directly so HIP compiler options don't leak to CXX-only targets.

**Device RNG fix:** `random_generator.h` selected the thrust-backed engine only under `__CUDACC__`, so under hipcc (`__HIPCC__`) the engine/distribution typedefs fell back to the host-only `std::` versions, leaving the device RNG unavailable on ROCm (the jittered / basic_jittered_blend samplers and `hip_sched`'s render kernel construct `random_generator<T>` on the device). Both guards now also accept `__HIPCC__`, mirroring the `__CUDACC__ || __HIPCC__` pattern already used in `macros.h`, `math.h`, and the LBVH builder. We made every effort to keep the CUDA path unchanged: every edit to a shared file is either a guard that widens from `__CUDACC__` to `__CUDACC__ || __HIPCC__` (which nvcc still evaluates true) or is gated behind `__HIPCC__` / `__HIP_DEVICE_COMPILE__` / `if(VSNRAY_ENABLE_HIP)`, so an nvcc build sees the same active code as before.

The README documents the ROCm/HIP build alongside the CUDA instructions.

## Test plan

Built and ran on an AMD Instinct MI250X (gfx90a, wave64), ROCm 7.2.1; also built and validated on gfx1100 (RDNA3) and gfx1201 (RDNA4):

```bash
cmake -B build -DCMAKE_BUILD_TYPE=Release \
  -DVSNRAY_ENABLE_HIP=ON -DVSNRAY_ENABLE_CUDA=OFF \
  -DVSNRAY_ENABLE_UNITTESTS=OFF -DVSNRAY_ENABLE_COMMON=ON \
  -DVSNRAY_ENABLE_VIEWER=OFF -DVSNRAY_ENABLE_EXAMPLES=OFF \
  -DCMAKE_HIP_ARCHITECTURES=gfx90a \
  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++
cmake --build build --target hip_test hip_random_test -j

HIP_VISIBLE_DEVICES=0 ./build/test/hip_test
# Device: AMD Instinct MI250X / MI250; Warp size: 64; PASS: Basic HIP test succeeded
HIP_VISIBLE_DEVICES=0 ./build/test/hip_random_test
# samples=32768 min=1.2144e-05 max=0.99997 mean=0.499811
# PASS: device random_generator produced finite, varied values
```

This work was authored with assistance from Claude (Anthropic).
