### PR TITLE
Fix riscv SIMD detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ make
 make install
 ```
 
+When targeting `riscv64`, make sure the selected compiler flags match the target CPU instead of the build host. Visionaray currently falls back to its builtin no-SIMD implementation on RISC-V unless a dedicated backend is added.
+
 Headers, libraries and binaries will then be located in the standard install path of your operating system (usually `/usr/local`).
 
 See the [Getting Started Guide](https://github.com/szellmann/visionaray/wiki/Getting-started) and the [Troubleshooting section](https://github.com/szellmann/visionaray/wiki/Troubleshooting) in the [Wiki](https://github.com/szellmann/visionaray/wiki) for further information.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ make
 make install
 ```
 
-When targeting `riscv64`, make sure the selected compiler flags match the target CPU instead of the build host. Visionaray currently falls back to its builtin no-SIMD implementation on RISC-V unless a dedicated backend is added.
+When cross-compiling, make sure the selected compiler flags match the target CPU instead of the build host.
 
 Headers, libraries and binaries will then be located in the standard install path of your operating system (usually `/usr/local`).
 

--- a/include/visionaray/math/detail/math.h
+++ b/include/visionaray/math/detail/math.h
@@ -9,16 +9,15 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <ctime>
 #include <type_traits>
 
-#ifdef _WIN32
+#if defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64))
 #include <xmmintrin.h>
 #include <mmintrin.h>
 #include <immintrin.h>
-#else
-#if !defined(__aarch64__)
+#elif defined(__i386__) || defined(__x86_64__) || defined(__amd64__)
 #include <x86intrin.h>
-#endif
 #endif
 
 #include "../config.h"
@@ -96,10 +95,12 @@ inline uint64_t clock64()
     uint64_t cnt;
     asm volatile("mrs %0, cntvct_el0" : "=r" (cnt));
     return cnt;
-#else
+#elif defined(__i386__) || defined(__x86_64__) || defined(__amd64__)
     unsigned int lo,hi;
     __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));
     return ((uint64_t)hi << 32) | lo;
+#else
+    return static_cast<uint64_t>(std::clock());
 #endif
 }
 #endif

--- a/include/visionaray/math/simd/intrinsics.h
+++ b/include/visionaray/math/simd/intrinsics.h
@@ -11,22 +11,32 @@
 #define VSNRAY_BASE_ARCH_UNKNOWN  9999
 #define VSNRAY_BASE_ARCH_X86         0
 #define VSNRAY_BASE_ARCH_ARM      1000
+#define VSNRAY_BASE_ARCH_RISCV    2000
 
 #define VSNRAY_ARCH_UNKNOWN          0
 #define VSNRAY_ARCH_X86             10
 #define VSNRAY_ARCH_X86_64          11
 #define VSNRAY_ARCH_ARM             20
 #define VSNRAY_ARCH_ARM64           21
+#define VSNRAY_ARCH_RISCV32         30
+#define VSNRAY_ARCH_RISCV64         31
 
-#if defined(_M_X64) || defined(_M_AMD64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
-#define VSNRAY_BASE_ARCH VSNRAY_BASE_ARCH_X86
-#define VSNRAY_ARCH VSNRAY_ARCH_X86_64
+#if defined(__riscv)
+#define VSNRAY_BASE_ARCH VSNRAY_BASE_ARCH_RISCV
+#if defined(__riscv_xlen) && (__riscv_xlen == 64)
+#define VSNRAY_ARCH VSNRAY_ARCH_RISCV64
+#else
+#define VSNRAY_ARCH VSNRAY_ARCH_RISCV32
+#endif
 #elif defined(__arm__) || defined(__arm) || defined(_ARM) || defined(_M_ARM)
 #define VSNRAY_BASE_ARCH VSNRAY_BASE_ARCH_ARM
 #define VSNRAY_ARCH VSNRAY_ARCH_ARM
 #elif defined(__aarch64__)
 #define VSNRAY_BASE_ARCH VSNRAY_BASE_ARCH_ARM
 #define VSNRAY_ARCH VSNRAY_ARCH_ARM64
+#elif defined(_M_X64) || defined(_M_AMD64) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
+#define VSNRAY_BASE_ARCH VSNRAY_BASE_ARCH_X86
+#define VSNRAY_ARCH VSNRAY_ARCH_X86_64
 #else
 #define VSNRAY_BASE_ARCH VSNRAY_BASE_ARCH_UNKNOWN
 #define VSNRAY_ARCH VSNRAY_ARCH_UNKNOWN
@@ -53,6 +63,7 @@
 
 #ifndef VSNRAY_NO_SIMD
 #ifndef VSNRAY_SIMD_ISA_
+#if VSNRAY_BASE_ARCH == VSNRAY_BASE_ARCH_X86
 #if defined(__AVX512F__)                            && !defined(__CUDACC__) // nvcc does not support AVX intrinsics
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_AVX512F
 #elif defined(__AVX2__)                             && !defined(__CUDACC__)
@@ -69,10 +80,17 @@
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_SSE3
 #elif defined(__SSE2__) || VSNRAY_ARCH == VSNRAY_ARCH_X86_64 // SSE2 is always available on 64-bit Intel compatible platforms
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_SSE2
-#elif defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP)) // Compiler on Jetson Nano doesn't define __ARM_NEON_FP although supported.
+#else
+#define VSNRAY_SIMD_ISA_ 0
+#endif
+#elif VSNRAY_BASE_ARCH == VSNRAY_BASE_ARCH_ARM
+#if defined(__ARM_NEON) && (defined(__ARM_NEON_FP) || defined(__ARM_FP)) // Compiler on Jetson Nano doesn't define __ARM_NEON_FP although supported.
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_NEON_FP
 #elif defined(__ARM_NEON)
 #define VSNRAY_SIMD_ISA_ VSNRAY_SIMD_ISA_NEON
+#else
+#define VSNRAY_SIMD_ISA_ 0
+#endif
 #else
 #define VSNRAY_SIMD_ISA_ 0
 #endif


### PR DESCRIPTION
## Why

Visionaray already has a builtin no-SIMD fallback that can serve as a conservative baseline for `riscv64`, but its architecture and SIMD detection currently rely on raw host compiler macros. In practice this lets host `x86_64` architecture and SSE state leak into simulated or cross-target `riscv64` builds, which selects the wrong backend and includes the wrong intrinsics headers.

## What changed

- Update `include/visionaray/math/simd/intrinsics.h` to recognize `__riscv` explicitly and distinguish `riscv32` from `riscv64`.
- Rework SIMD ISA detection so x86 SSE/AVX probing only runs when the selected base architecture is x86, and ARM NEON probing only runs when the selected base architecture is ARM.
- Leave all non-x86 and non-ARM targets, including `riscv64`, on the existing builtin no-SIMD fallback instead of inheriting host SIMD state.
- Guard `include/visionaray/math/detail/math.h` so x86 intrinsics headers and `rdtsc` are only used on x86/x64, while non-x86 targets fall back to a conservative generic timer path.
- Update `README.md` with a generic cross-compilation note so target CPU flags do not accidentally follow the build host.

## Verification

- Ran native CMake configuration with Ninja and optional components disabled to validate the public library/export path:
  - `cmake -S . -B build-native-min -G Ninja -DVSNRAY_ENABLE_CUDA=OFF -DVSNRAY_ENABLE_COMMON=OFF -DVSNRAY_ENABLE_VIEWER=OFF -DVSNRAY_ENABLE_EXAMPLES=OFF -DVSNRAY_ENABLE_UNITTESTS=OFF`
- Ran the native build successfully:
  - `cmake --build build-native-min --parallel 4`
- Ran the native install successfully and verified the exported headers and package files were produced:
  - `cmake --install build-native-min --prefix build-native-min\install`
- Ran a real `riscv64` cross-build in `dockcross/linux-riscv64` for a minimal consumer that includes `visionaray/math/simd/simd.h` and `visionaray/math/vector.h`.
- Verified the produced executable with:
  - `file`
  - `readelf -h`
- Ran the resulting binary under `qemu-riscv64` and confirmed the vector arithmetic smoke test prints:
  - `visionaray-ok 5 7 9 10 21 36`
- Confirmed the native x86 CMake configuration still succeeds after the generic fallback fix.

## Notes

This is a conservative portability patch. It does not add RVV or any other RISC-V SIMD backend. The goal is to make `riscv64` select Visionaray's existing builtin fallback correctly and to prevent host `x86_64` intrinsics or timing code from leaking into cross-target validation.
