### PR TITLE
Add a compile-only HIP CI job (and fix the documented HIP build)

### DIFF
--- a/.github/workflows/visionaray-ci.yml
+++ b/.github/workflows/visionaray-ci.yml
@@ -72,3 +72,41 @@ jobs:
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config }} --target install
+
+  build-hip:
+    runs-on: ubuntu-24.04
+    container: rocm/dev-ubuntu-24.04:7.2.4-complete
+    strategy:
+      matrix:
+        config: [Release, Debug]
+
+    name: HIP build - config ${{ matrix.config }}
+
+    # GitHub-hosted runners have no AMD GPU, so this job is a compile-only gate
+    # (it builds the HIP device code offline but does not run it), mirroring the
+    # CUDA matrix entry above. Running the device tests needs a runner with an
+    # AMD GPU.
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Install apt packages
+      run: |
+        apt-get update
+        apt-get install -y cmake git libboost-all-dev libglew-dev freeglut3-dev libxi-dev libxmu-dev
+
+    - name: Configure CMake
+      run: >
+        cmake -LA -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+        -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++
+        -DCMAKE_HIP_ARCHITECTURES="gfx90a;gfx1100;gfx1201"
+        -DVSNRAY_ENABLE_HIP:BOOL=ON
+        -DVSNRAY_ENABLE_CUDA:BOOL=OFF
+        -DVSNRAY_ENABLE_COMMON:BOOL=ON
+        -DVSNRAY_ENABLE_VIEWER:BOOL=OFF
+        -DVSNRAY_ENABLE_EXAMPLES:BOOL=OFF
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.config }}

--- a/.github/workflows/visionaray-ci.yml
+++ b/.github/workflows/visionaray-ci.yml
@@ -87,14 +87,19 @@ jobs:
     # CUDA matrix entry above. Running the device tests needs a runner with an
     # AMD GPU.
     steps:
+    # git must be present before checkout, otherwise actions/checkout falls back
+    # to the REST API download, which cannot fetch submodules.
+    - name: Install git
+      run: |
+        apt-get update
+        apt-get install -y git
+
     - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Install apt packages
-      run: |
-        apt-get update
-        apt-get install -y cmake git libboost-all-dev libglew-dev freeglut3-dev libxi-dev libxmu-dev
+      run: apt-get install -y cmake libboost-all-dev libglew-dev freeglut3-dev libxi-dev libxmu-dev
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/visionaray-ci.yml
+++ b/.github/workflows/visionaray-ci.yml
@@ -105,6 +105,7 @@ jobs:
       run: >
         cmake -LA -B ${{github.workspace}}/build
         -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+        -DCMAKE_PREFIX_PATH=/opt/rocm
         -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++
         -DCMAKE_HIP_ARCHITECTURES="gfx90a;gfx1100;gfx1201"
         -DVSNRAY_ENABLE_HIP:BOOL=ON

--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ Visionaray's GPU path also targets AMD GPUs through ROCm/HIP. Enable it with `-D
 cmake .. -DCMAKE_BUILD_TYPE=Release \
   -DVSNRAY_ENABLE_HIP=ON -DVSNRAY_ENABLE_CUDA=OFF \
   -DCMAKE_HIP_ARCHITECTURES=gfx90a \
-  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++
+  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
+  -DCMAKE_PREFIX_PATH=/opt/rocm
 make
 ```
+
+If ROCm is not installed under the default prefix, or `/opt/rocm/bin` is not on your `PATH`, point `-DCMAKE_PREFIX_PATH` at your ROCm install so CMake can locate the hipCUB and rocThrust packages.
 
 ### Windows
 


### PR DESCRIPTION
Follow-up to #51, in response to your question about adding HIP to CI. Two related changes, both addressing what breaks on a clean ROCm environment (a fresh container with no ROCm on PATH):

1. A compile-only `build-hip` CI job. It compiles the HIP device code in the official rocm/dev-ubuntu-24.04 container. Like the existing CUDA matrix entry, it runs on a GitHub-hosted runner that has no AMD GPU, so it is a compilation gate rather than a runtime test: it builds the HIP targets (hip_test, hip_random_test) offline for gfx90a, gfx1100, and gfx1201 but does not execute them. This catches HIP build regressions (header drift, hip* API renames, CMake wiring) across ROCm releases. Running the device tests would require a runner with an AMD GPU (a self-hosted runner, or one of the GPU-backed hosted-runner programs), which is the part that depends on hardware access rather than a workflow edit.

2. A one-line README fix. The HIP build block set the HIP compiler by absolute path but then relied on find_package(hip/hipCUB/rocThrust) discovering ROCm via /opt/rocm/bin being on PATH. On a clean install where ROCm is not on PATH, the documented command fails with hip_DIR-NOTFOUND. Passing CMAKE_PREFIX_PATH=/opt/rocm makes the command work as written. Standing up the CI job is what surfaced this: the container reproduced exactly the clean-environment case the README did not cover.

The build-hip job is green on this branch (both Release and Debug).
