### PR TITLE
[ROCm] Complete the HIP GPU path: device_vector, BVH traversal, device-code fixes

### DIFF
--- a/include/visionaray/detail/aligned_allocator.h
+++ b/include/visionaray/detail/aligned_allocator.h
@@ -11,7 +11,7 @@
 #include <new>
 
 #include "compiler.h"
-#if VSNRAY_CXX_MSVC
+#if defined(_WIN32)
 #include <malloc.h>
 #endif
 
@@ -47,7 +47,7 @@ public:
 
     pointer allocate(size_type n, void* /* hint */ = 0)
     {
-#if VSNRAY_CXX_MSVC
+#if defined(_WIN32)
         return (pointer)_mm_malloc(n * sizeof(T), A);
 #else
         value_type* ptr{nullptr};
@@ -62,7 +62,7 @@ public:
 
     void deallocate(pointer p, size_type /* n */)
     {
-#if VSNRAY_CXX_MSVC
+#if defined(_WIN32)
         _mm_free(p);
 #else
         std::free(p);

--- a/include/visionaray/detail/bvh/intersect.inl
+++ b/include/visionaray/detail/bvh/intersect.inl
@@ -15,7 +15,11 @@
 #include "../tags.h"
 #include "hit_record.h"
 
-#if defined( __CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+// Use the standard stack-based BVH traversal on all platforms.
+// The trail-bit stackless traversal (__CUDA_ARCH__ path) hangs on AMD RDNA3
+// (gfx1100) due to compiler code-generation differences; the stack<32>
+// traversal is correct and sufficient for any practical BVH depth.
+#if defined(__CUDA_ARCH__)
 #define VSNRAY_FULL_STACK_TRAVERSAL_ 0
 #else
 #define VSNRAY_FULL_STACK_TRAVERSAL_ 1

--- a/include/visionaray/hip/detail/device_vector.inl
+++ b/include/visionaray/hip/detail/device_vector.inl
@@ -1,6 +1,9 @@
 // This file is distributed under the MIT license.
 // See the LICENSE file for details.
 
+#include <algorithm>
+#include <utility>
+
 #include <hip/hip_runtime.h>
 
 #include "../fill.h"
@@ -63,7 +66,8 @@ device_vector<T>::device_vector(size_t size, T const& value)
 }
 
 template <typename T>
-device_vector<T>::device_vector(host_vector<T> const &hv)
+template <typename A>
+device_vector<T>::device_vector(std::vector<T, A> const &hv)
     : size_(hv.size())
 {
     HIP_SAFE_CALL(hipMalloc(&data_, sizeof(T) * size_));
@@ -73,6 +77,20 @@ device_vector<T>::device_vector(host_vector<T> const &hv)
         sizeof(T) * size_,
         hipMemcpyHostToDevice
         ));
+}
+
+template <typename T>
+template <typename A>
+device_vector<T>::operator std::vector<T, A>() const
+{
+    std::vector<T, A> hv(size_);
+    HIP_SAFE_CALL(hipMemcpy(
+        hv.data(),
+        data_,
+        sizeof(T) * size_,
+        hipMemcpyDeviceToHost
+        ));
+    return hv;
 }
 
 template <typename T>
@@ -157,16 +175,18 @@ device_vector<T>& device_vector<T>::operator=(std::vector<T, A> const& rhs)
 }
 
 template <typename T>
-void device_vector<T>::resize(size_t size)
+void device_vector<T>::reserve(size_t size)
 {
-    if (size_ == size)
+    if (size <= capacity_)
+    {
         return;
+    }
 
     T* prev{nullptr};
     size_t copy_size{0};
-    if (size_ > 0)
+    if (capacity_ > 0)
     {
-        copy_size = std::min(size_, size);
+        copy_size = std::min(capacity_, size);
         HIP_SAFE_CALL(hipMalloc(&prev, copy_size * sizeof(T)));
         HIP_SAFE_CALL(hipMemcpy(
             prev,
@@ -177,9 +197,9 @@ void device_vector<T>::resize(size_t size)
         HIP_SAFE_CALL(hipDeviceSynchronize());
     }
 
-    size_ = size;
+    capacity_ = size;
     HIP_SAFE_CALL(hipFree(data_));
-    HIP_SAFE_CALL(hipMalloc(&data_, sizeof(T) * size_));
+    HIP_SAFE_CALL(hipMalloc(&data_, sizeof(T) * capacity_));
 
     if (prev && copy_size > 0)
     {
@@ -195,6 +215,16 @@ void device_vector<T>::resize(size_t size)
 }
 
 template <typename T>
+void device_vector<T>::resize(size_t size)
+{
+    if (size_ == size)
+        return;
+
+    reserve(size);
+    size_ = size;
+}
+
+template <typename T>
 void device_vector<T>::resize(size_t size, T const& value)
 {
     size_t prev_size = size_;
@@ -206,6 +236,42 @@ void device_vector<T>::resize(size_t size, T const& value)
         size_t more = size_ - prev_size;
         hip::fill(data_ + prev_size, more * sizeof(T), &value, sizeof(value));
     }
+}
+
+template <typename T>
+void device_vector<T>::push_back(T const& value)
+{
+  resize(size_ + 1);
+
+  HIP_SAFE_CALL(hipMemcpy(
+        data_ + size_,
+        &value,
+        sizeof(T),
+        hipMemcpyHostToDevice
+        ));
+}
+
+template <typename T>
+template <typename... Args>
+void device_vector<T>::emplace_back(Args&&... args)
+{
+  T value(std::forward<Args>(args)...);
+  resize(size_ + 1);
+
+  HIP_SAFE_CALL(hipMemcpy(
+        data_ + size_,
+        &value,
+        sizeof(T),
+        hipMemcpyHostToDevice
+        ));
+}
+
+template <typename T>
+void device_vector<T>::clear()
+{
+    HIP_SAFE_CALL(hipFree(data_));
+    capacity_ = 0;
+    size_ = 0;
 }
 
 template <typename T>

--- a/include/visionaray/hip/device_vector.h
+++ b/include/visionaray/hip/device_vector.h
@@ -7,6 +7,7 @@
 #define VSNRAY_HIP_DEVICE_VECTOR_H 1
 
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "../detail/macros.h"
@@ -39,7 +40,8 @@ public:
 
     device_vector(size_t size);
     device_vector(size_t size, T const& value);
-    device_vector(host_vector<T> const& hv);
+    template <typename A>
+    device_vector(std::vector<T, A> const& hv);
     device_vector(const T* data, size_t size);
     device_vector(const T* begin, const T* end);
 
@@ -49,8 +51,19 @@ public:
     template <typename A>
     device_vector& operator=(std::vector<T, A> const& rhs);
 
+    template <typename A>
+    explicit operator std::vector<T, A>() const;
+
+    void reserve(size_t size);
     void resize(size_t size);
     void resize(size_t size, T const& value);
+
+    void push_back(T const& value);
+
+    template<typename... Args>
+    void emplace_back(Args&&... args);
+
+    void clear();
 
     T* data();
     T const* data() const;
@@ -73,6 +86,7 @@ public:
 private:
     T* data_{nullptr};
     size_t size_{0};
+    size_t capacity_{0};
 };
 
 } // hip

--- a/include/visionaray/math/detail/math.h
+++ b/include/visionaray/math/detail/math.h
@@ -135,19 +135,21 @@ inline T max(T const& x, T const& y)
 MATH_FUNC
 inline int reinterpret_as_int(float a)
 {
-    // Use memcpy bc. of strict-aliasing rules
-    int i;
-    memcpy(&i, &a, sizeof(i));
-    return i;
+    // Union-based type pun: valid in C, and works in __device__ code where
+    // memcpy is not available as a __device__ function.
+    union { float f; int i; } u;
+    u.f = a;
+    return u.i;
 }
 
 MATH_FUNC
 inline float reinterpret_as_float(int a)
 {
-    // Use memcpy bc. of strict-aliasing rules
-    float f;
-    memcpy(&f, &a, sizeof(f));
-    return f;
+    // Union-based type pun: valid in C, and works in __device__ code where
+    // memcpy is not available as a __device__ function.
+    union { int i; float f; } u;
+    u.i = a;
+    return u.f;
 }
 
 MATH_FUNC

--- a/include/visionaray/math/detail/math.h
+++ b/include/visionaray/math/detail/math.h
@@ -135,21 +135,23 @@ inline T max(T const& x, T const& y)
 MATH_FUNC
 inline int reinterpret_as_int(float a)
 {
-    // Union-based type pun: valid in C, and works in __device__ code where
-    // memcpy is not available as a __device__ function.
-    union { float f; int i; } u;
-    u.f = a;
-    return u.i;
+    // __builtin_memcpy is strict-aliasing-safe and lowers to a bit
+    // reinterpretation. Unlike the libc memcpy it is available in __device__
+    // code: HIP provides no __device__ memcpy overload, so a plain memcpy here
+    // fails to compile for HIP device code.
+    int i;
+    __builtin_memcpy(&i, &a, sizeof(i));
+    return i;
 }
 
 MATH_FUNC
 inline float reinterpret_as_float(int a)
 {
-    // Union-based type pun: valid in C, and works in __device__ code where
-    // memcpy is not available as a __device__ function.
-    union { int i; float f; } u;
-    u.i = a;
-    return u.f;
+    // See reinterpret_as_int: __builtin_memcpy avoids the strict-aliasing UB of
+    // a union pun and is available in both HIP and CUDA __device__ code.
+    float f;
+    __builtin_memcpy(&f, &a, sizeof(f));
+    return f;
 }
 
 MATH_FUNC


### PR DESCRIPTION
Follow-up to #51 (HIP/ROCm support). #51 added the HIP build and passed the trivial-kernel tests, but the full GPU rendering path needed more to compile under HIP and to run correctly on AMD hardware. This PR completes that path. The CUDA and CPU code paths are untouched.

**device_vector host-side container interface.** The HIP `device_vector` only implemented the methods the trivial-kernel tests exercise, so the GPU BVH builder path did not compile under HIP: constructing a `hip_index_bvh` from a host-built BVH (`build_top_down`) needs the host-side container interface that `cuda::device_vector` already provides. Adds, mirroring `cuda::device_vector` one to one:

- `reserve(size_t)` with growth semantics (new `capacity_` member); `resize` refactored to use it
- `push_back` / `emplace_back(Args&&...)` / `clear`
- the templated `std::vector<T, A>` constructor and `explicit operator std::vector<T, A>()` (the BVH vectors use `aligned_allocator`, not the default allocator)

**BVH traversal hang on RDNA3.** The trail-bit stackless traversal hangs the kernel on RDNA3 (gfx1100, wave32). Narrow the stackless path to `__CUDA_ARCH__` and use the full `stack<32>` traversal for HIP device code (and host code); it is correct on every arch at the cost of slightly more stack. CUDA device code keeps the stackless path unchanged. The observable was a runtime hang, not a build failure.

**Type-pun helpers in device code.** `reinterpret_as_int` / `reinterpret_as_float` used libc `memcpy`, which is not callable from HIP device code: HIP has no `__device__` memcpy overload, unlike CUDA. Use `__builtin_memcpy`, which is strict-aliasing-safe, available in both HIP and CUDA device code, and lowers to a bit reinterpretation. (It also avoids the C++ undefined behavior of a union pun reading the inactive member.)

**aligned_allocator on Windows.** Select `_mm_malloc` / `_mm_free` (and `<malloc.h>`) on `_WIN32` rather than `VSNRAY_CXX_MSVC`. `VSNRAY_CXX_MSVC` is 0 under Clang on Windows, so the allocator previously fell through to the POSIX `posix_memalign` path, which is not available there.

Test Plan:

Built the in-progress anari-visionaray HIP device (which builds `hip_index_bvh` sampling BVHs for unstructured/AMR volume fields) against these headers and rendered triangle-surface and structuredRegular-volume scenes headless, comparing against the CPU device:

- gfx90a (AMD Instinct MI250X, ROCm 7.2): nonzero, varied framebuffers matching the CPU device.
- gfx1100 (AMD Radeon Pro W7800, ROCm 7.2): the same scenes render correctly; this is the configuration that exposed the BVH traversal hang, now fixed.

The existing `hip_test` / `hip_random_test` build and pass on both. The `__builtin_memcpy` change produces gfx1100 device code that is bit-identical to the prior union-based revision.

Authored with the assistance of Claude (Anthropic) as part of an effort to bring ROCm/HIP support to GPU-accelerated open source projects.