### PR TITLE
Fix race condition in thread pool

### DIFF
--- a/include/visionaray/detail/thread_pool.h
+++ b/include/visionaray/detail/thread_pool.h
@@ -59,12 +59,12 @@ public:
             return;
         }
 
-	{
-		std::lock_guard<std::mutex> lock(sync_params.mutex);
-		sync_params.start_threads = true;
-        	sync_params.join_threads = true;
-	}
-        sync_params.threads_start.notify_all();
+        sync_params.start_threads = true;
+        sync_params.join_threads = true;
+        {
+            std::unique_lock<std::mutex> lock(sync_params.mutex);
+            sync_params.threads_start.notify_all();
+        }
 
         for (unsigned i = 0; i < num_threads; ++i)
         {
@@ -106,21 +106,18 @@ public:
         sync_params.work_items_finished_counter = 0;
 
         // Activate persistent threads
-	{
-        	std::lock_guard<std::mutex> lock(sync_params.mutex);
-		sync_params.start_threads = true;
-	}
-        sync_params.threads_start.notify_all();
+        sync_params.start_threads = true;
+        {
+            std::unique_lock<std::mutex> lock(sync_params.mutex);
+            sync_params.threads_start.notify_all();
+        }
 
         // Wait for all threads to finish
         sync_params.threads_ready.wait();
 
         // Idle w/o work
-	{
 		
-		std::lock_guard<std::mutex> lock(sync_params.mutex);
-		sync_params.start_threads = false;
-	}
+	sync_params.start_threads = false;
     }
 
     std::unique_ptr<std::thread[]> threads;

--- a/include/visionaray/detail/thread_pool.h
+++ b/include/visionaray/detail/thread_pool.h
@@ -60,7 +60,6 @@ public:
         }
 
 	{
-		std::cout << "changes enforced\n" << std::endl;
 		std::lock_guard<std::mutex> lock(sync_params.mutex);
 		sync_params.start_threads = true;
         	sync_params.join_threads = true;

--- a/include/visionaray/detail/thread_pool.h
+++ b/include/visionaray/detail/thread_pool.h
@@ -59,8 +59,12 @@ public:
             return;
         }
 
-        sync_params.start_threads = true;
-        sync_params.join_threads = true;
+	{
+		std::cout << "changes enforced\n" << std::endl;
+		std::lock_guard<std::mutex> lock(sync_params.mutex);
+		sync_params.start_threads = true;
+        	sync_params.join_threads = true;
+	}
         sync_params.threads_start.notify_all();
 
         for (unsigned i = 0; i < num_threads; ++i)
@@ -103,14 +107,21 @@ public:
         sync_params.work_items_finished_counter = 0;
 
         // Activate persistent threads
-        sync_params.start_threads = true;
+	{
+        	std::lock_guard<std::mutex> lock(sync_params.mutex);
+		sync_params.start_threads = true;
+	}
         sync_params.threads_start.notify_all();
 
         // Wait for all threads to finish
         sync_params.threads_ready.wait();
 
         // Idle w/o work
-        sync_params.start_threads = false;
+	{
+		
+		std::lock_guard<std::mutex> lock(sync_params.mutex);
+		sync_params.start_threads = false;
+	}
     }
 
     std::unique_ptr<std::thread[]> threads;


### PR DESCRIPTION
`start_threads` is now updated while holding the associated mutex before calling `notify_all()`. This avoids a race condition between updating the shared variable and waking the worker threads.

This change fixes a deadlock observed in a multithreaded application using the thread pool.